### PR TITLE
feat/add-prop-type-theme-to-breadcrumb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chic-ui",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chic-ui",
-      "version": "1.0.5",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "final-form": "^4.20.7",

--- a/src/components/breadcrumb/__tests__/__snapshots__/breadcrumb.spec.tsx.snap
+++ b/src/components/breadcrumb/__tests__/__snapshots__/breadcrumb.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Breadcrumb Component Renders Correctly 1`] = `
 <ol
-  className="sc-bdfBQB RJtEk"
+  className="sc-bdfBQB cnZHxH"
 >
   <li
     className="breadcrumb-item"

--- a/src/components/breadcrumb/breadcrumb.stories.tsx
+++ b/src/components/breadcrumb/breadcrumb.stories.tsx
@@ -1,9 +1,17 @@
+import React from 'react';
 import { Story, Meta } from '@storybook/react';
 import Breadcrumb, { BreadcrumbProps } from '.';
+import { theme } from '../../tokens/themes';
 
 export default {
   title: 'Components/Breadcrumb',
-  component: Breadcrumb
+  component: Breadcrumb,
+  argTypes: {
+    type: {
+      options: Object.keys(theme),
+      control: { type: 'radio' }
+    },
+  }
 } as Meta;
 
 const options = {

--- a/src/components/breadcrumb/breadcrumb.tsx
+++ b/src/components/breadcrumb/breadcrumb.tsx
@@ -1,10 +1,13 @@
 import React, { ReactNode } from 'react';
 import { StyledBreadcrumb } from './styled';
 
+import type { themeType } from 'src/tokens/themes';
+
 interface BaseBreadcrumbProps {
   className?: string;
   separator?: ReactNode | string;
   style?: any;
+  type?: themeType;
 }
 
 interface BreadcrumbItemProps {
@@ -15,7 +18,7 @@ interface BreadcrumbSeparatorProps {
   children?: ReactNode;
 }
 
-const Breadcrumb: React.FC<BreadcrumbProps> = ({ separator, ...props }) => {
+const Breadcrumb: React.FC<BreadcrumbProps> = ({ separator, type = 'primary', ...props }) => {
   let children = React.Children.toArray(props.children);
 
   const totalItems = children.length;
@@ -26,7 +29,7 @@ const Breadcrumb: React.FC<BreadcrumbProps> = ({ separator, ...props }) => {
     .map(toBreadcrumbItem)
     .reduce(withSeparator(lastIndex, separator), []);
 
-  return <StyledBreadcrumb {...props}>{children}</StyledBreadcrumb>;
+  return <StyledBreadcrumb themeColor={type} {...props}>{children}</StyledBreadcrumb>;
 };
 
 const toBreadcrumbItem = (child: ReactNode, index: number) => (

--- a/src/components/breadcrumb/styled.ts
+++ b/src/components/breadcrumb/styled.ts
@@ -1,7 +1,11 @@
 import styled from 'styled-components';
-import { theme as typeColors } from '../../tokens/themes';
+import { themeType, theme as typeColors  } from '../../tokens/themes';
 
-export const StyledBreadcrumb = styled.ol`
+interface StyledBreadcrumbProps {
+  themeColor: themeType
+}
+
+export const StyledBreadcrumb = styled.ol<StyledBreadcrumbProps>`
   list-style: none;
   display: flex;
   align-items: center;
@@ -9,10 +13,22 @@ export const StyledBreadcrumb = styled.ol`
   flex-direction: row;
 
   .breadcrumb-separator {
-    display: flex;
     align-items: center;
-    color: ${typeColors.light.color};
+    color: ${({ themeColor }) => typeColors[themeColor].bgColor};
+    display: flex;
     margin: auto 6px;
     user-select: none;
+  }
+
+  .breadcrumb-item {
+    color: ${({ themeColor }) => typeColors[themeColor].bgColor};
+  }
+
+  .breadcrumb-item:hover {
+    color: ${({ themeColor }) => typeColors[themeColor].hover};
+  }
+
+  a { 
+    color: inherit;
   }
 `;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -19,9 +23,11 @@
     "sourceMap": true,
     "noFallthroughCasesInSwitch": true,
     "baseUrl": ".",
-    "noEmit": false
+    "noEmit": true
   },
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "exclude": [
     "node_modules",
     "**/*.test.ts",


### PR DESCRIPTION
Closes issue #98 

___

**What changes**

- New `prop` `type` in component `Breadcrumb` based in theme

___

**Evidencies**
![image](https://user-images.githubusercontent.com/75763403/193417261-1c43585d-71b3-46b9-b500-ccaa584e3a8f.png)
