### PR TITLE
Feat: Add prop to make Progress Bar striped

### DIFF
--- a/src/components/progressBar/__tests__/__snapshots__/progressbar.spec.tsx.snap
+++ b/src/components/progressBar/__tests__/__snapshots__/progressbar.spec.tsx.snap
@@ -3,10 +3,10 @@
 exports[`ProgressBar Component Renders Correctly 1`] = `
 Array [
   <div
-    className="sc-gsTEea kDUPfF"
+    className="sc-gsTEea dYAXdu"
   >
     <div
-      className="sc-bdfBQB ePBJvV"
+      className="sc-bdfBQB gxZpio"
       type="danger"
       width={80}
     >
@@ -31,19 +31,19 @@ Array [
     </div>
   </div>,
   <div
-    className="sc-gsTEea kDUPfF"
+    className="sc-gsTEea dYAXdu"
   >
     <div
-      className="sc-bdfBQB gqPdhi"
+      className="sc-bdfBQB ibDUNn"
       type="success"
       width={60}
     />
   </div>,
   <div
-    className="sc-gsTEea kDUPfF"
+    className="sc-gsTEea dYAXdu"
   >
     <div
-      className="sc-bdfBQB VfOvq"
+      className="sc-bdfBQB ezkAWj"
       type="primary"
       width={40}
     >
@@ -62,6 +62,62 @@ Array [
           type="primary"
         >
           40
+          % 
+        </span>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="sc-gsTEea dYAXdu"
+  >
+    <div
+      className="sc-bdfBQB cVFWwR"
+      type="primary"
+      width={20}
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "height": "100%",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          className="sc-dlfnuX eNxsCi"
+          type="primary"
+        >
+          20
+          % 
+        </span>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="sc-gsTEea dYAXdu"
+  >
+    <div
+      className="sc-bdfBQB hzzFmi"
+      type="primary"
+      width={30}
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "height": "100%",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          className="sc-dlfnuX eNxsCi"
+          type="primary"
+        >
+          30
           % 
         </span>
       </div>

--- a/src/components/progressBar/__tests__/__snapshots__/progressbar.spec.tsx.snap
+++ b/src/components/progressBar/__tests__/__snapshots__/progressbar.spec.tsx.snap
@@ -123,5 +123,61 @@ Array [
       </div>
     </div>
   </div>,
+  <div
+    className="sc-gsTEea dYAXdu"
+  >
+    <div
+      className="sc-bdfBQB kSFVlq"
+      type="primary"
+      width={40}
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "height": "100%",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          className="sc-dlfnuX eNxsCi"
+          type="primary"
+        >
+          40
+          % 
+        </span>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="sc-gsTEea dYAXdu"
+  >
+    <div
+      className="sc-bdfBQB jYaUQp"
+      type="primary"
+      width={50}
+    >
+      <div
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "height": "100%",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          className="sc-dlfnuX eNxsCi"
+          type="primary"
+        >
+          50
+          % 
+        </span>
+      </div>
+    </div>
+  </div>,
 ]
 `;

--- a/src/components/progressBar/__tests__/progressbar.spec.tsx
+++ b/src/components/progressBar/__tests__/progressbar.spec.tsx
@@ -9,6 +9,8 @@ describe('ProgressBar Component', () => {
         <ProgressBar progress={80} type="danger" />
         <ProgressBar progress={60} type="success" showProgress={false} />
         <ProgressBar progress={40} animated />
+        <ProgressBar progress={20} striped />
+        <ProgressBar progress={30} striped animated />
       </>
     );
     expect(ProgressBarGroup).toMatchSnapshot();

--- a/src/components/progressBar/__tests__/progressbar.spec.tsx
+++ b/src/components/progressBar/__tests__/progressbar.spec.tsx
@@ -11,6 +11,8 @@ describe('ProgressBar Component', () => {
         <ProgressBar progress={40} animated />
         <ProgressBar progress={20} striped />
         <ProgressBar progress={30} striped animated />
+        <ProgressBar progress={40} striped stripedAnimated />
+        <ProgressBar progress={50} striped stripedAnimated animated />
       </>
     );
     expect(ProgressBarGroup).toMatchSnapshot();

--- a/src/components/progressBar/progressBar.stories.tsx
+++ b/src/components/progressBar/progressBar.stories.tsx
@@ -24,5 +24,6 @@ Default.args = {
   type: 'primary',
   showProgress: true,
   animated: false,
-  striped: false
+  striped: false,
+  stripedAnimated: false
 };

--- a/src/components/progressBar/progressBar.stories.tsx
+++ b/src/components/progressBar/progressBar.stories.tsx
@@ -23,5 +23,6 @@ Default.args = {
   progress: 80,
   type: 'primary',
   showProgress: true,
-  animated: false
+  animated: false,
+  striped: false
 };

--- a/src/components/progressBar/progressBar.tsx
+++ b/src/components/progressBar/progressBar.tsx
@@ -11,6 +11,7 @@ export interface ProgressBarProps {
   type?: themeType;
   showProgress?: boolean;
   animated?: boolean;
+  striped?: boolean;
 }
 
 const ProgressBar: React.ForwardRefRenderFunction<
@@ -26,7 +27,7 @@ const ProgressBar: React.ForwardRefRenderFunction<
 
   return (
     <StyledProgressWrapper>
-      <StyledProgressBar type={type} width={progress} animated={animated}>
+      <StyledProgressBar width={progress} {...props}>
         {showProgress && (
           <div
             style={{

--- a/src/components/progressBar/progressBar.tsx
+++ b/src/components/progressBar/progressBar.tsx
@@ -18,12 +18,7 @@ const ProgressBar: React.ForwardRefRenderFunction<
   HTMLAnchorElement,
   ProgressBarProps
 > = (props, ref) => {
-  const {
-    progress = 70,
-    type = 'primary',
-    showProgress = true,
-    animated = false
-  } = props;
+  const { progress = 70, type = 'primary', showProgress = true } = props;
 
   return (
     <StyledProgressWrapper>

--- a/src/components/progressBar/progressBar.tsx
+++ b/src/components/progressBar/progressBar.tsx
@@ -19,10 +19,14 @@ const ProgressBar: React.ForwardRefRenderFunction<
   ProgressBarProps
 > = (props, ref) => {
   const { progress = 70, type = 'primary', showProgress = true } = props;
-
   return (
     <StyledProgressWrapper>
-      <StyledProgressBar width={progress} {...props}>
+      <StyledProgressBar
+        type={type}
+        width={progress}
+        showProgress={showProgress}
+        {...props}
+      >
         {showProgress && (
           <div
             style={{

--- a/src/components/progressBar/progressBar.tsx
+++ b/src/components/progressBar/progressBar.tsx
@@ -12,6 +12,7 @@ export interface ProgressBarProps {
   showProgress?: boolean;
   animated?: boolean;
   striped?: boolean;
+  stripedAnimated?: boolean;
 }
 
 const ProgressBar: React.ForwardRefRenderFunction<
@@ -19,6 +20,7 @@ const ProgressBar: React.ForwardRefRenderFunction<
   ProgressBarProps
 > = (props, ref) => {
   const { progress = 70, type = 'primary', showProgress = true } = props;
+
   return (
     <StyledProgressWrapper>
       <StyledProgressBar

--- a/src/components/progressBar/styled.ts
+++ b/src/components/progressBar/styled.ts
@@ -6,6 +6,7 @@ interface StyledProgressBarProps {
   animated?: boolean;
   width?: number;
   striped?: boolean;
+  stripedAnimated?: boolean;
 }
 
 interface StyledLoadingTextProps {
@@ -48,8 +49,7 @@ export const StyledProgressBar = styled.div<StyledProgressBarProps>`
     `};
 
   ${(pr) =>
-    pr.animated &&
-    pr.striped &&
+    pr.stripedAnimated &&
     css`
       animation: ${animationAttributes};
     `};

--- a/src/components/progressBar/styled.ts
+++ b/src/components/progressBar/styled.ts
@@ -5,6 +5,7 @@ interface StyledProgressBarProps {
   type?: themeType;
   animated?: boolean;
   width?: number;
+  striped?: boolean;
 }
 
 interface StyledLoadingTextProps {
@@ -14,10 +15,25 @@ interface StyledLoadingTextProps {
 export const StyledProgressBar = styled.div<StyledProgressBarProps>`
   display: inline-block;
   height: 25px;
+  border-radius: 8px;
   background-color: ${(pr) => typeColors[pr.type!].bgColor};
   width: ${(pr) => pr.width}%;
   ${(pr) => pr.animated && `transition: width 1s ease-in-out`};
-  border-radius: 8px;
+  ${(pr) =>
+    pr.striped &&
+    `background-image: linear-gradient(
+        135deg, 
+        hsla(0, 0%, 100%, .25) 25%,
+        transparent 0,
+        transparent 50%,
+        hsla(0, 0%, 100%, .25) 0,
+        hsla(0, 0%, 100%, .25) 75%,
+        transparent 0,
+        transparent
+      );
+      background-size: 40px 40px;
+      background-repeat: repeat;
+    `};
 `;
 
 export const StyledProgressWrapper = styled.div`

--- a/src/components/progressBar/styled.ts
+++ b/src/components/progressBar/styled.ts
@@ -15,12 +15,12 @@ interface StyledLoadingTextProps {
 // Animation
 const animationAttributes = () =>
   css`
-    ${key} 5s linear infinite
+    ${keys} 30s linear infinite
   `;
 
-const key = keyframes`
-    0% { background-position-x: 0.1px }
-    100% { background-position-x: 25% }
+const keys = keyframes`
+    0% { background-position-x: 0vw }
+    100% { background-position-x: 100vw }
 `;
 
 export const StyledProgressBar = styled.div<StyledProgressBarProps>`
@@ -45,6 +45,12 @@ export const StyledProgressBar = styled.div<StyledProgressBarProps>`
       );
       background-size: 40px 40px;
       background-repeat: repeat;
+    `};
+
+  ${(pr) =>
+    pr.animated &&
+    pr.striped &&
+    css`
       animation: ${animationAttributes};
     `};
 `;

--- a/src/components/progressBar/styled.ts
+++ b/src/components/progressBar/styled.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { keyframes, css } from 'styled-components';
 import { themeType, theme as typeColors } from '../../tokens/themes';
 
 interface StyledProgressBarProps {
@@ -12,6 +12,17 @@ interface StyledLoadingTextProps {
   type?: themeType;
 }
 
+// Animation
+const animationAttributes = () =>
+  css`
+    ${key} 5s linear infinite
+  `;
+
+const key = keyframes`
+    0% { background-position-x: 0.1px }
+    100% { background-position-x: 25% }
+`;
+
 export const StyledProgressBar = styled.div<StyledProgressBarProps>`
   display: inline-block;
   height: 25px;
@@ -21,18 +32,20 @@ export const StyledProgressBar = styled.div<StyledProgressBarProps>`
   ${(pr) => pr.animated && `transition: width 1s ease-in-out`};
   ${(pr) =>
     pr.striped &&
-    `background-image: linear-gradient(
-        135deg, 
-        hsla(0, 0%, 100%, .25) 25%,
+    css`
+      background-image: linear-gradient(
+        135deg,
+        hsla(0, 0%, 100%, 0.25) 25%,
         transparent 0,
         transparent 50%,
-        hsla(0, 0%, 100%, .25) 0,
-        hsla(0, 0%, 100%, .25) 75%,
+        hsla(0, 0%, 100%, 0.25) 0,
+        hsla(0, 0%, 100%, 0.25) 75%,
         transparent 0,
         transparent
       );
       background-size: 40px 40px;
       background-repeat: repeat;
+      animation: ${animationAttributes};
     `};
 `;
 


### PR DESCRIPTION
Close issue: #105 

**Description:**
Add two props to progress-bar component: `striped` and `stripedAnimated`. Both booleans.

Behavior shown in the video below

Open to listening to any note, suggestion or something wrong =D

https://user-images.githubusercontent.com/54823205/193624744-d097ab89-41ed-4ad6-8c82-490a63773198.mp4

**Great #hacktoberfest!**