### PR TITLE
Feat: Backdrop Component

### DIFF
--- a/src/components/backdrop/__tests__/__snapshots__/backdrop.spec.tsx.snap
+++ b/src/components/backdrop/__tests__/__snapshots__/backdrop.spec.tsx.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Backdrop Component Renders Correctly 1`] = `
+Array [
+  <div
+    className="sc-bdfBQB fiZSsf"
+  />,
+  <div
+    className="sc-bdfBQB gqAeyi"
+    color="#e4f0f4"
+  />,
+  <div
+    className="sc-bdfBQB gzdGhb"
+  />,
+]
+`;

--- a/src/components/backdrop/__tests__/backdrop.spec.tsx
+++ b/src/components/backdrop/__tests__/backdrop.spec.tsx
@@ -1,0 +1,16 @@
+import Backdrop from '..';
+import { render } from '../../../test/utils';
+
+/* eslint-disable */
+describe('Backdrop Component', () => {
+  it('Renders Correctly', () => {
+    const BackdropGroup = render(
+      <>
+        <Backdrop />
+        <Backdrop color="#e4f0f4" />
+        <Backdrop zIndex={120} visible={false} />
+      </>
+    );
+    expect(BackdropGroup).toMatchSnapshot();
+  });
+});

--- a/src/components/backdrop/backdrop.stories.tsx
+++ b/src/components/backdrop/backdrop.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import Backdrop, { BackdropProps } from '.';
+
+export default {
+  title: 'Components/Backdrop',
+  component: Backdrop
+} as Meta;
+
+const Template: Story<BackdropProps> = (args) => <Backdrop {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  color: 'black',
+  zIndex: 101,
+  relative: true
+};
+
+export const Coloured = Template.bind({});
+Coloured.args = {
+  color: 'gray',
+  relative: true
+};
+
+export const NotVisible = Template.bind({});
+NotVisible.args = {
+  visible: false
+};

--- a/src/components/backdrop/backdrop.tsx
+++ b/src/components/backdrop/backdrop.tsx
@@ -1,0 +1,21 @@
+import React, { MouseEventHandler } from 'react';
+import { StyledBackdrop } from './styled';
+
+export interface BackdropProps {
+  visible?: boolean;
+  color?: string;
+  relative?: boolean;
+  zIndex?: number;
+  onClick?: MouseEventHandler<HTMLDivElement>;
+}
+
+export const Backdrop: React.ForwardRefRenderFunction<
+  HTMLDivElement,
+  BackdropProps
+> = (props, ref) => {
+  const { visible=true, color, zIndex, relative } = props;
+  console.log(props)
+  return <StyledBackdrop visible={visible} color={color} zIndex={zIndex} relative={relative}  />;
+};
+
+export default React.forwardRef<HTMLDivElement, BackdropProps>(Backdrop);

--- a/src/components/backdrop/backdrop.tsx
+++ b/src/components/backdrop/backdrop.tsx
@@ -5,8 +5,8 @@ export interface BackdropProps {
   visible?: boolean;
   color?: string;
   relative?: boolean;
-  zIndex?: number;
   onClick?: MouseEventHandler<HTMLDivElement>;
+  zIndex?: number;
 }
 
 export const Backdrop: React.ForwardRefRenderFunction<

--- a/src/components/backdrop/index.ts
+++ b/src/components/backdrop/index.ts
@@ -1,0 +1,5 @@
+import { Backdrop } from './backdrop'
+
+export * from "./backdrop"
+
+export default Backdrop

--- a/src/components/backdrop/styled.ts
+++ b/src/components/backdrop/styled.ts
@@ -1,0 +1,14 @@
+import styled from "styled-components";
+import { BackdropProps } from './backdrop'
+
+
+export const StyledBackdrop = styled.div<BackdropProps>`
+display: ${props => props.visible ? 'block' : 'none'};
+position: ${props => props.relative ? 'relative' : 'fixed'};
+left: 0;
+top: 0;
+width: 100vw;
+height: 100vh;
+z-index: ${props => props.zIndex ? props.zIndex : 101};
+background: ${props => props.color ? props.color : '#000'};
+`


### PR DESCRIPTION
hey @karishmashuklaa pls check :D
the prop relative is also added (changes the position from fixed to relative for backdrop) because the backdrop was taking the width of entire canvas and the props were not visible on docs page of storybook