### PR TITLE
feat: make `Backdrop` object extensible

### DIFF
--- a/src/components/backdrop/backdrop.tsx
+++ b/src/components/backdrop/backdrop.tsx
@@ -15,6 +15,9 @@ export const Backdrop: React.ForwardRefRenderFunction<
   BackdropProps
 > = (props, ref) => {
   const { visible = true, color, style, className, children, onClick } = props;
+
+  const refObject = ref || React.createRef<HTMLDivElement>();
+
   return (
     <StyledBackdrop
       visible={visible}
@@ -22,7 +25,7 @@ export const Backdrop: React.ForwardRefRenderFunction<
       style={style}
       className={className}
       onClick={onClick}
-      ref={ref}
+      ref={refObject}
     >
       {children}
     </StyledBackdrop>

--- a/src/components/backdrop/backdrop.tsx
+++ b/src/components/backdrop/backdrop.tsx
@@ -17,6 +17,7 @@ export const Backdrop: React.ForwardRefRenderFunction<
   const { visible = true, color, style, className, children, onClick } = props;
 
   const refObject = ref || React.createRef<HTMLDivElement>();
+  const newRefObject = Object.assign({}, refObject);
 
   return (
     <StyledBackdrop
@@ -25,7 +26,7 @@ export const Backdrop: React.ForwardRefRenderFunction<
       style={style}
       className={className}
       onClick={onClick}
-      ref={refObject}
+      ref={newRefObject}
     >
       {children}
     </StyledBackdrop>


### PR DESCRIPTION
closes #150 

it's happening because we are trying to add a current property to a ref object that is not extensible.

hence we are creating a new reference object using `Object.assign()` that is extensible and then adding the refObject to it. 